### PR TITLE
chore(docker): add Qdrant service to docker-compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,6 +13,9 @@ services:
       - ./config-overrides.json:/app/config-overrides.json
     env_file:
       - .env
+    depends_on:
+      qdrant:
+        condition: service_healthy
     restart: unless-stopped
 
     healthcheck:
@@ -32,3 +35,29 @@ services:
       options:
         max-size: "10m"
         max-file: "3"
+
+  qdrant:
+    image: qdrant/qdrant:latest
+    container_name: qdrant
+    ports:
+      - "6333:6333"
+      - "6334:6334"
+    volumes:
+      - qdrant_data:/qdrant/storage
+    restart: unless-stopped
+
+    healthcheck:
+      test: ["CMD", "wget", "--quiet", "--tries=1", "--spider", "http://localhost:6333/healthz"]
+      interval: 30s
+      timeout: 5s
+      retries: 3
+      start_period: 5s
+
+    deploy:
+      resources:
+        limits:
+          memory: 1G
+
+volumes:
+  qdrant_data:
+    driver: local


### PR DESCRIPTION
- Add Qdrant vector database service with persistent storage
- Add health check and depends_on for service ordering
- Expose ports 6333 (HTTP) and 6334 (gRPC)