### PR TITLE
fix(ci): source Docker tags from semantic-release version

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -40,7 +40,8 @@ jobs:
         run: bun test
 
       - name: Run semantic-release
-        run: bunx semantic-release
+        id: semantic
+        uses: codfish/semantic-release-action@v5
         env:
           GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
 
@@ -49,26 +50,54 @@ jobs:
         uses: docker/setup-buildx-action@v3
 
       - name: Log in to GitHub Container Registry
+        if: steps.semantic.outputs.new-release-published == 'true'
         uses: docker/login-action@v3
         with:
           registry: ghcr.io
           username: ${{ github.repository_owner }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Extract version from package.json
-        id: package-version
+      - name: Derive Docker tags from semantic-release
+        if: steps.semantic.outputs.new-release-published == 'true'
+        id: docker-tags
         run: |
-          VERSION=$(node -p "require('./package.json').version")
-          echo "version=$VERSION" >> $GITHUB_OUTPUT
-          echo "Detected version: $VERSION"
+          VERSION="${{ steps.semantic.outputs.release-version }}"
+
+          if [ -z "$VERSION" ]; then
+            echo "semantic-release did not provide release-version" >&2
+            exit 1
+          fi
+
+          if [[ "$VERSION" == *"-"* ]]; then
+            TAGS="ghcr.io/${{ github.repository_owner }}/gitea-ai-assistant:${VERSION}"
+          else
+            MAJOR="${VERSION%%.*}"
+            REST="${VERSION#*.}"
+            MINOR="${REST%%.*}"
+
+            TAGS=$(printf '%s\n' \
+              "ghcr.io/${{ github.repository_owner }}/gitea-ai-assistant:latest" \
+              "ghcr.io/${{ github.repository_owner }}/gitea-ai-assistant:${MAJOR}" \
+              "ghcr.io/${{ github.repository_owner }}/gitea-ai-assistant:${MAJOR}.${MINOR}" \
+              "ghcr.io/${{ github.repository_owner }}/gitea-ai-assistant:${VERSION}")
+          fi
+
+          {
+            echo "tags<<EOF"
+            echo "$TAGS"
+            echo "EOF"
+          } >> "$GITHUB_OUTPUT"
+
+          echo "Release version: ${VERSION}"
+          echo "Docker tags to push:"
+          echo "$TAGS"
 
       - name: Build and push Docker image
+        if: steps.semantic.outputs.new-release-published == 'true'
         uses: docker/build-push-action@v5
         with:
           context: .
           push: true
-          tags: |
-            ghcr.io/${{ github.repository_owner }}/gitea-ai-assistant:latest
-            ghcr.io/${{ github.repository_owner }}/gitea-ai-assistant:${{ steps.package-version.outputs.version }}
+          tags: ${{ steps.docker-tags.outputs.tags }}
           cache-from: type=gha
           cache-to: type=gha,mode=max

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gitea-assistant",
-  "version": "1.0.0",
+  "version": "0.0.0-develop",
   "description": "Gitea功能增强助手，包含AI代码审核功能",
   "engines": {
     "bun": ">=1.2.5"


### PR DESCRIPTION
Avoid stale image tags from placeholder package.json and prevent prereleases from overwriting latest.

Ultraworked with [Sisyphus](https://github.com/code-yeongyu/oh-my-openagent)